### PR TITLE
Support for custom serializers

### DIFF
--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -70,7 +70,7 @@ namespace Refit
     }
 
     public enum BodySerializationMethod {
-        Json, UrlEncoded
+        Json, UrlEncoded, Custom
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -1,4 +1,8 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace Refit
 {
@@ -7,9 +11,12 @@ namespace Refit
         public RefitSettings()
         {
             UrlParameterFormatter = new DefaultUrlParameterFormatter();
+            CustomSerializers = new Dictionary<Type, ITypeSerializer>();
         }
 
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
+
+        public Dictionary<Type, ITypeSerializer> CustomSerializers { get; private set; }
     }
 
     public interface IUrlParameterFormatter
@@ -23,5 +30,11 @@ namespace Refit
         {
             return parameterValue != null ? parameterValue.ToString() : null;
         }
+    }
+
+    public interface ITypeSerializer
+    {
+        HttpContent SerializeAsHttpContent(object value);
+        Task<object> DeserializeFromHttpContent(HttpContent content);
     }
 }


### PR DESCRIPTION
@paulcbetts This is just a first-pass at it so we can talk about the approach. 

I've added `BodySerializationMethod.Custom`, because it saved having to change the signature of `RestMethodInfo.BodyParameterInfo` (and it makes a few things easier later), but it's not _required_ -- `RestMethodInfo.findBodyParameter()` treats any parameter with a type in `RefitSettings.CustomSerializers` as a body parameter.

Keen to see if this is like what you'd imagined us doing?

One thing I've done a bit differently to what you suggested was that I've made `ITypeSerializer.SerializeAsHttpContent()` synchronous. Making it async pushes a massive amount of changes through the codebase (mostly in tests, to be fair), but do we actually need to do it for serializing the _request_ body?

At least the following are still to do:
- [ ] Make `ITypeSerializer.SerializeAsHttpContent()` async (maybe?)
- [ ] Merge in #80 or add `RefitSettings` to `RestMethodInfo` and deal with the conflicts later.
- [ ] Add a basic XML serializer as a reference
- [ ] Write tests

This will resolve #75.
