### PR TITLE
Always use compression if the client supports it

### DIFF
--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -38,7 +39,11 @@ namespace Refit
 
         public static T For<T>(string hostUrl, RefitSettings settings)
         {
-            var client = new HttpClient() { BaseAddress = new Uri(hostUrl) };
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression) {
+                handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+            }
+            var client = new HttpClient(handler) { BaseAddress = new Uri(hostUrl) };
             return RestService.For<T>(client, settings);
         }
 


### PR DESCRIPTION
This will greatly reduce the size of the response making requests faster