### PR TITLE
Moved ApiException into the Portable project

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -505,62 +505,6 @@ namespace Refit
         }
     }
 
-    public class ApiException : Exception
-    {
-        public HttpStatusCode StatusCode { get; private set; }
-        public string ReasonPhrase { get; private set; }
-        public HttpResponseHeaders Headers { get; private set; }
-
-        public HttpContentHeaders ContentHeaders { get; private set; }
-
-        public string Content { get; private set; }
-
-        public bool HasContent {
-            get { return !String.IsNullOrWhiteSpace(Content); }
-        }
-        public RefitSettings RefitSettings{get;set;}
-
-        ApiException(HttpStatusCode statusCode, string reasonPhrase, HttpResponseHeaders headers, RefitSettings refitSettings = null) : 
-            base(createMessage(statusCode, reasonPhrase)) 
-        {
-            StatusCode = statusCode;
-            ReasonPhrase = reasonPhrase;
-            Headers = headers;
-            RefitSettings = refitSettings;
-        }
-
-        public T GetContentAs<T>()
-        {
-            return HasContent ? 
-                JsonConvert.DeserializeObject<T>(Content, RefitSettings.JsonSerializerSettings) : 
-                default(T);
-        }
-
-        public static async Task<ApiException> Create(HttpResponseMessage response, RefitSettings refitSettings = null) 
-        {
-            var exception = new ApiException(response.StatusCode, response.ReasonPhrase, response.Headers, refitSettings);
-
-            if (response.Content == null) return exception;
-            
-            try {
-                exception.ContentHeaders = response.Content.Headers;
-                exception.Content = await response.Content.ReadAsStringAsync();
-                response.Content.Dispose();
-            } catch {
-                // NB: We're already handling an exception at this point, 
-                // so we want to make sure we don't throw another one 
-                // that hides the real error.
-            }
-            
-            return exception;
-        }
-
-        static string createMessage(HttpStatusCode statusCode, string reasonPhrase)
-        {
-            return String.Format("Response status code does not indicate success: {0} ({1}).", (int)statusCode, reasonPhrase);
-        }
-    }
-
     class FormValueDictionary : Dictionary<string, string>
     {
         static readonly Dictionary<Type, PropertyInfo[]> propertyCache

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using System.Threading;
+using Newtonsoft.Json;
 
 namespace Refit
 {
@@ -45,6 +48,64 @@ namespace Refit
         public static T For<T>(string hostUrl)
         {
             return RestService.For<T>(hostUrl, null);
+        }
+    }
+
+    public class ApiException : Exception
+    {
+        public HttpStatusCode StatusCode { get; private set; }
+        public string ReasonPhrase { get; private set; }
+        public HttpResponseHeaders Headers { get; private set; }
+
+        public HttpContentHeaders ContentHeaders { get; private set; }
+
+        public string Content { get; private set; }
+
+        public bool HasContent
+        {
+            get { return !String.IsNullOrWhiteSpace(Content); }
+        }
+        public RefitSettings RefitSettings { get; set; }
+
+        ApiException(HttpStatusCode statusCode, string reasonPhrase, HttpResponseHeaders headers, RefitSettings refitSettings = null) :
+            base(createMessage(statusCode, reasonPhrase))
+        {
+            StatusCode = statusCode;
+            ReasonPhrase = reasonPhrase;
+            Headers = headers;
+            RefitSettings = refitSettings;
+        }
+
+        public T GetContentAs<T>()
+        {
+            return HasContent ?
+                JsonConvert.DeserializeObject<T>(Content, RefitSettings.JsonSerializerSettings) :
+                default(T);
+        }
+
+        public static async Task<ApiException> Create(HttpResponseMessage response, RefitSettings refitSettings = null)
+        {
+            var exception = new ApiException(response.StatusCode, response.ReasonPhrase, response.Headers, refitSettings);
+
+            if (response.Content == null)
+                return exception;
+
+            try {
+                exception.ContentHeaders = response.Content.Headers;
+                exception.Content = await response.Content.ReadAsStringAsync();
+                response.Content.Dispose();
+            } catch {
+                // NB: We're already handling an exception at this point, 
+                // so we want to make sure we don't throw another one 
+                // that hides the real error.
+            }
+
+            return exception;
+        }
+
+        static string createMessage(HttpStatusCode statusCode, string reasonPhrase)
+        {
+            return String.Format("Response status code does not indicate success: {0} ({1}).", (int)statusCode, reasonPhrase);
         }
     }
 }


### PR DESCRIPTION
This should allow projects that use the Refit library directly (i.e. other PCLs) to catch `ApiException`.

This is super lazy, but putting `ApiException` in `RestService.cs` means I don't have to change 230958 project files.

Fixes #126.