### PR TITLE
Header fixes

### DIFF
--- a/Refit-Tests/RequestBuilder.cs
+++ b/Refit-Tests/RequestBuilder.cs
@@ -282,6 +282,9 @@ namespace Refit.Tests
         [Get("/foo/bar/{id}")]
         Task<string> FetchSomeStuffWithCustomHeader(int id, [Header("X-Emoji")] string custom);
 
+        [Post("/foo/bar/{id}")]
+        Task<string> PostSomeStuffWithCustomHeader(int id, [Body] object body, [Header("X-Emoji")] string emoji);
+
         [Get("/string")]
         Task<string> FetchSomeStuffWithoutFullPath();
 
@@ -502,6 +505,19 @@ namespace Refit.Tests
             var output = factory(new object[] { 6, null });
 
             Assert.IsNull(output.Headers.Authorization, "Headers include Authorization header");
+        }
+
+        [Test]
+        public void AddCustomHeadersToRequestHeadersOnly()
+        {
+            var fixture = new RequestBuilderImplementation(typeof(IDummyHttpApi));
+            var factory = fixture.BuildRequestFactoryForMethod("PostSomeStuffWithCustomHeader");
+            var output = factory(new object[] { 6, new { Foo = "bar" }, ":smile_cat:" });
+
+            Assert.IsTrue(output.Headers.Contains("Api-Version"), "Headers include Api-Version header");
+            Assert.IsTrue(output.Headers.Contains("X-Emoji"), "Headers include X-Emoji header");
+            Assert.IsFalse(output.Content.Headers.Contains("Api-Version"), "Content headers include Api-Version header");
+            Assert.IsFalse(output.Content.Headers.Contains("X-Emoji"), "Content headers include X-Emoji header");
         }
 
         [Test]

--- a/Refit-Tests/RequestBuilder.cs
+++ b/Refit-Tests/RequestBuilder.cs
@@ -275,6 +275,10 @@ namespace Refit.Tests
         [Headers("Api-Version: ")]
         Task<string> FetchSomeStuffWithEmptyHardcodedHeader(int id);
 
+        [Post("/foo/bar/{id}")]
+        [Headers("Content-Type: literally/anything")]
+        Task<string> PostSomeStuffWithHardCodedContentTypeHeader(int id, [Body] string content);
+
         [Get("/foo/bar/{id}")]
         [Headers("Authorization: SRSLY aHR0cDovL2kuaW1ndXIuY29tL0NGRzJaLmdpZg==")]
         Task<string> FetchSomeStuffWithDynamicHeader(int id, [Header("Authorization")] string authorization);
@@ -462,6 +466,17 @@ namespace Refit.Tests
             Assert.IsTrue(output.Headers.Contains("User-Agent"), "Headers include User-Agent header");
             Assert.AreEqual("RefitTestClient", output.Headers.UserAgent.ToString());
             Assert.IsFalse(output.Headers.Contains("Api-Version"), "Headers include Api-Version header");
+        }
+
+        [Test]
+        public void ContentHeadersCanBeHardcoded()
+        {
+            var fixture = new RequestBuilderImplementation(typeof(IDummyHttpApi));
+            var factory = fixture.BuildRequestFactoryForMethod("PostSomeStuffWithHardCodedContentTypeHeader");
+            var output = factory(new object[] { 6, "stuff" });
+
+            Assert.IsTrue(output.Content.Headers.Contains("Content-Type"), "Content headers include Content-Type header");
+            Assert.AreEqual("literally/anything", output.Content.Headers.ContentType.ToString());
         }
 
         [Test]


### PR DESCRIPTION
This PR contains the fixes for both of the outstanding header related bugs (#121 and #136).

* Adding of all headers is now deferred until the body parameter has been added to the request. This means `Content` is there and we can add headers to it.
* We now only try to add to the content headers collection if adding to the request headers collection failed.

![Okay](http://i1.kym-cdn.com/photos/images/original/000/692/496/cd9.png)