### PR TITLE
Uri template

### DIFF
--- a/Refit/PortableRefitSettings.cs
+++ b/Refit/PortableRefitSettings.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Refit
+{
+    public class RefitSettings
+    {
+        public RefitSettings()
+        {
+        }
+        public JsonSerializerSettings JsonSerializerSettings { get; set; }
+        public IUrlParameterFormatter UrlParameterFormatter { get; set; }
+        public IUriTemplateHandler UriTemplateHandler { get; set; }
+    }
+
+    public interface IUriTemplateHandler
+    {
+        Uri GetRequestUri(IUrlParameterFormatter urlParameterFormatter, RestMethodInfo restMethod, object[] paramList, string basePath = "");   
+    }
+
+    public interface IUrlParameterFormatter
+    {
+        string Format(object value, ParameterInfo parameterInfo);
+    }
+
+    public class DefaultUrlParameterFormatter : IUrlParameterFormatter
+    {
+        public virtual string Format(object parameterValue, ParameterInfo parameterInfo)
+        {
+            return parameterValue != null ? parameterValue.ToString() : null;
+        }
+    }
+
+    public class DefaultUriTemplateHandler : IUriTemplateHandler
+    {
+
+        public Uri GetRequestUri(IUrlParameterFormatter urlParameterFormatter, RestMethodInfo restMethod, object[] paramList, string basePath = "")
+        {
+            return null;
+        }
+    }
+
+}

--- a/Refit/PortableRestMethodInfo.cs
+++ b/Refit/PortableRestMethodInfo.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+
+namespace Refit
+{
+    public class RestMethodInfo
+    {
+        public string Name { get; set; }
+        public Type Type { get; set; }
+        public MethodInfo MethodInfo { get; set; }
+        public HttpMethod HttpMethod { get; set; }
+        public string RelativePath { get; set; }
+        public Dictionary<int, string> ParameterMap { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<int, string> HeaderParameterMap { get; set; }
+        public Tuple<BodySerializationMethod, int> BodyParameterInfo { get; set; }
+        public Dictionary<int, string> QueryParameterMap { get; set; }
+        public Dictionary<int, ParameterInfo> ParameterInfoMap { get; set; }
+        public Type ReturnType { get; set; }
+        public Type SerializedReturnType { get; set; }
+        public RefitSettings RefitSettings { get; set; }
+
+        public RestMethodInfo(Type targetInterface, MethodInfo methodInfo, RefitSettings refitSettings = null)
+        {
+        }
+
+        
+    }
+}

--- a/Refit/Refit-Net45.csproj
+++ b/Refit/Refit-Net45.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -61,6 +60,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RefitSettings.cs" />
     <Compile Include="RequestBuilderImplementation.cs" />
+    <Compile Include="RestMethodInfo.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="Attributes.cs" />
     <Compile Include="Helpers.cs" />

--- a/Refit/Refit-Portable.csproj
+++ b/Refit/Refit-Portable.csproj
@@ -38,8 +38,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Attributes.cs" />
+    <Compile Include="PortableRefitSettings.cs" />
+    <Compile Include="PortableRestMethodInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RefitSettings.cs" />
     <Compile Include="RequestBuilder.cs" />
     <Compile Include="RestService.cs" />
   </ItemGroup>

--- a/Refit/Refit-WPA81.csproj
+++ b/Refit/Refit-WPA81.csproj
@@ -71,6 +71,7 @@
     <Compile Include="NameValueCollection.cs" />
     <Compile Include="RequestBuilder.cs" />
     <Compile Include="RequestBuilderImplementation.cs" />
+    <Compile Include="RestMethodInfo.cs" />
     <Compile Include="RestService.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="RefitSettings.cs" />

--- a/Refit/Refit-WinRT45.csproj
+++ b/Refit/Refit-WinRT45.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestBuilder.cs" />
     <Compile Include="RequestBuilderImplementation.cs" />
+    <Compile Include="RestMethodInfo.cs" />
     <Compile Include="RestService.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="RefitSettings.cs" />

--- a/Refit/Refit-wp8.csproj
+++ b/Refit/Refit-wp8.csproj
@@ -113,14 +113,13 @@
     <Compile Include="NameValueCollection.cs" />
     <Compile Include="RequestBuilder.cs" />
     <Compile Include="RequestBuilderImplementation.cs" />
+    <Compile Include="RestMethodInfo.cs" />
     <Compile Include="RestService.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="RefitSettings.cs" />
   </ItemGroup>
-
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
-
   <ProjectExtensions />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -1,7 +1,11 @@
-﻿using System.Reflection;
-
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using HttpUtility = System.Web.HttpUtility;
 namespace Refit
 {
     public class RefitSettings
@@ -9,9 +13,17 @@ namespace Refit
         public RefitSettings()
         {
             UrlParameterFormatter = new DefaultUrlParameterFormatter();
+            UrlTemplateHandler = new DefaultUrlTemplateHandler();
         }
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
+        public IUrlTemplateHandler UrlTemplateHandler { get; set; }
+    }
+
+    public interface IUrlTemplateHandler
+    {
+        IEnumerable<string> GetParameterNames(string template);
+        Uri GetRequestUri(IUrlParameterFormatter urlParameterFormatter, RestMethodInfo restMethod, object[] paramList, string basePath = "");   
     }
 
     public interface IUrlParameterFormatter
@@ -26,4 +38,73 @@ namespace Refit
             return parameterValue != null ? parameterValue.ToString() : null;
         }
     }
+
+    public class DefaultUrlTemplateHandler : IUrlTemplateHandler
+    {
+        static readonly Regex parameterRegex = new Regex(@"{(.*?)}");
+
+        public IEnumerable<string> GetParameterNames(string template)
+        {
+            var parameterizedParts = template.Split('/', '?')
+                .SelectMany(x => parameterRegex.Matches(x).Cast<Match>())
+                .ToList();
+            return parameterizedParts.Select(p => p.Groups[1].Value.ToLowerInvariant()).ToList();
+        }
+        public Uri GetRequestUri(IUrlParameterFormatter urlParameterFormatter, RestMethodInfo restMethod, object[] paramList, string basePath = "")
+        {
+            string urlTarget = (basePath == "/" ? String.Empty : basePath) + restMethod.RelativePath;
+            var queryParamsToAdd = new Dictionary<string, string>();
+
+            for (int i = 0; i < paramList.Length; i++)
+            {
+
+                if (restMethod.ParameterMap.ContainsKey(i))
+                {
+                    urlTarget = Regex.Replace(
+                        urlTarget,
+                        "{" + restMethod.ParameterMap[i] + "}",
+                        urlParameterFormatter.Format(paramList[i], restMethod.ParameterInfoMap[i]),
+                        RegexOptions.IgnoreCase);
+                    continue;
+                }
+
+                if (restMethod.BodyParameterInfo != null && restMethod.BodyParameterInfo.Item2 == i)
+                {
+                    continue;
+                }
+
+                if (!restMethod.HeaderParameterMap.ContainsKey(i))
+                {
+                    if (paramList[i] != null)
+                    {
+                        queryParamsToAdd[restMethod.QueryParameterMap[i]] = urlParameterFormatter.Format(paramList[i], restMethod.ParameterInfoMap[i]);
+                    }
+                }
+            }
+
+            // NB: The URI methods in .NET are dumb. Also, we do this 
+            // UriBuilder business so that we preserve any hardcoded query 
+            // parameters as well as add the parameterized ones.
+            var uri = new UriBuilder(new Uri(new Uri("http://api"), urlTarget));
+            var query = HttpUtility.ParseQueryString(uri.Query ?? "");
+            foreach (var kvp in queryParamsToAdd)
+            {
+                query.Add(kvp.Key, kvp.Value);
+            }
+
+            if (query.HasKeys())
+            {
+                var pairs = query.Keys.Cast<string>().Select(x => HttpUtility.UrlEncode(x) + "=" + HttpUtility.UrlEncode(query[x]));
+                uri.Query = String.Join("&", pairs);
+            }
+            else
+            {
+                uri.Query = null;
+            }
+            return new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, UriFormat.UriEscaped), UriKind.Relative);
+        }
+
+   
+    }
+
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -69,16 +69,9 @@ namespace Refit
                     setHeader(ret, header.Key, header.Value);
                 }   
 
-                string urlTarget = (basePath == "/" ? String.Empty : basePath) + restMethod.RelativePath;
-                var queryParamsToAdd = new Dictionary<string, string>();
-
                 for(int i=0; i < paramList.Length; i++) {
+
                     if (restMethod.ParameterMap.ContainsKey(i)) {
-                        urlTarget = Regex.Replace(
-                            urlTarget, 
-                            "{" + restMethod.ParameterMap[i] + "}", 
-                            settings.UrlParameterFormatter.Format(paramList[i], restMethod.ParameterInfoMap[i]), 
-                            RegexOptions.IgnoreCase);
                         continue;
                     }
 
@@ -100,37 +93,15 @@ namespace Refit
                                 break;
                             }
                         }
-
                         continue;
                     }
 
-
                     if (restMethod.HeaderParameterMap.ContainsKey(i)) {
                         setHeader(ret, restMethod.HeaderParameterMap[i], paramList[i]);
-                    } else {
-                        if (paramList[i] != null) {
-                            queryParamsToAdd[restMethod.QueryParameterMap[i]] = settings.UrlParameterFormatter.Format(paramList[i], restMethod.ParameterInfoMap[i]);
-                        }
-                    }
+                    } 
                 }
 
-                // NB: The URI methods in .NET are dumb. Also, we do this 
-                // UriBuilder business so that we preserve any hardcoded query 
-                // parameters as well as add the parameterized ones.
-                var uri = new UriBuilder(new Uri(new Uri("http://api"), urlTarget));
-                var query = HttpUtility.ParseQueryString(uri.Query ?? "");
-                foreach(var kvp in queryParamsToAdd) {
-                    query.Add(kvp.Key, kvp.Value);
-                }
-
-                if (query.HasKeys()) {
-                    var pairs = query.Keys.Cast<string>().Select(x => HttpUtility.UrlEncode(x) + "=" + HttpUtility.UrlEncode(query[x]));
-                    uri.Query = String.Join("&", pairs);
-                } else {
-                    uri.Query = null;
-                }
-
-                ret.RequestUri = new Uri(uri.Uri.GetComponents(UriComponents.PathAndQuery, UriFormat.UriEscaped), UriKind.Relative);
+                ret.RequestUri = settings.UrlTemplateHandler.GetRequestUri(settings.UrlParameterFormatter, restMethod,paramList,basePath);
                 return ret;
             };
         }
@@ -299,209 +270,6 @@ namespace Refit
         public void Dispose()
         {
             block();
-        }
-    }
-
-    public class RestMethodInfo
-    {
-        public string Name { get; set; }
-        public Type Type { get; set; }
-        public MethodInfo MethodInfo { get; set; }
-        public HttpMethod HttpMethod { get; set; }
-        public string RelativePath { get; set; }
-        public Dictionary<int, string> ParameterMap { get; set; }
-        public Dictionary<string, string> Headers { get; set; }
-        public Dictionary<int, string> HeaderParameterMap { get; set; }
-        public Tuple<BodySerializationMethod, int> BodyParameterInfo { get; set; }
-        public Dictionary<int, string> QueryParameterMap { get; set; }
-        public Dictionary<int, ParameterInfo> ParameterInfoMap { get; set; }
-        public Type ReturnType { get; set; }
-        public Type SerializedReturnType { get; set; }
-        public RefitSettings RefitSettings { get; set; }
-
-        static readonly Regex parameterRegex = new Regex(@"{(.*?)}");
-
-        public RestMethodInfo(Type targetInterface, MethodInfo methodInfo, RefitSettings refitSettings = null)
-        {
-            RefitSettings = refitSettings ?? new RefitSettings();
-            Type = targetInterface;
-            Name = methodInfo.Name;
-            MethodInfo = methodInfo;
-
-            var hma = methodInfo.GetCustomAttributes(true)
-                .OfType<HttpMethodAttribute>()
-                .First();
-
-            HttpMethod = hma.Method;
-            RelativePath = hma.Path;
-
-            verifyUrlPathIsSane(RelativePath);
-            determineReturnTypeInfo(methodInfo);
-
-            var parameterList = methodInfo.GetParameters().ToList();
-            ParameterInfoMap = parameterList
-                .Select((parameter, index) => new { index, parameter })
-                .ToDictionary(x => x.index, x => x.parameter);
-            ParameterMap = buildParameterMap(RelativePath, parameterList);
-            BodyParameterInfo = findBodyParameter(parameterList);
-
-            Headers = parseHeaders(methodInfo);
-            HeaderParameterMap = buildHeaderParameterMap(parameterList);
-
-            QueryParameterMap = new Dictionary<int, string>();
-            for (int i=0; i < parameterList.Count; i++) {
-                if (ParameterMap.ContainsKey(i) || HeaderParameterMap.ContainsKey(i) || (BodyParameterInfo != null && BodyParameterInfo.Item2 == i)) {
-                    continue;
-                }
-
-                QueryParameterMap[i] = getUrlNameForParameter(parameterList[i]);
-            }
-        }
-
-        void verifyUrlPathIsSane(string relativePath) 
-        {
-            if (relativePath == "")
-                return;
-
-            if (!relativePath.StartsWith("/")) {
-                goto bogusPath;
-            }
-
-            var parts = relativePath.Split('/');
-            if (parts.Length == 0) {
-                goto bogusPath;
-            }
-
-            return;
-
-        bogusPath:
-            throw new ArgumentException("URL path must be of the form '/foo/bar/baz'");
-        }
-
-        Dictionary<int, string> buildParameterMap(string relativePath, List<ParameterInfo> parameterInfo)
-        {
-            var ret = new Dictionary<int, string>();
-
-            var parameterizedParts = relativePath.Split('/', '?')
-                .SelectMany(x => parameterRegex.Matches(x).Cast<Match>())
-                .ToList();
-
-            if (parameterizedParts.Count == 0) {
-                return ret;
-            }
-
-            var paramValidationDict = parameterInfo.ToDictionary(k => getUrlNameForParameter(k).ToLowerInvariant(), v => v);
-
-            foreach (var match in parameterizedParts) {
-                var name = match.Groups[1].Value.ToLowerInvariant();
-                if (!paramValidationDict.ContainsKey(name)) {
-                    throw new ArgumentException(String.Format("URL has parameter {0}, but no method parameter matches", name));
-                }
-
-                ret.Add(parameterInfo.IndexOf(paramValidationDict[name]), name);
-            }
-
-            return ret;
-        }
-
-        string getUrlNameForParameter(ParameterInfo paramInfo)
-        {
-            var aliasAttr = paramInfo.GetCustomAttributes(true)
-                .OfType<AliasAsAttribute>()
-                .FirstOrDefault();
-            return aliasAttr != null ? aliasAttr.Name : paramInfo.Name;
-        }
-
-        Tuple<BodySerializationMethod, int> findBodyParameter(List<ParameterInfo> parameterList)
-        {
-            var bodyParams = parameterList
-                .Select(x => new { Parameter = x, BodyAttribute = x.GetCustomAttributes(true).OfType<BodyAttribute>().FirstOrDefault() })
-                .Where(x => x.BodyAttribute != null)
-                .ToList();
-
-            if (bodyParams.Count > 1) {
-                throw new ArgumentException("Only one parameter can be a Body parameter");
-            }
-
-            if (bodyParams.Count == 0) {
-                return null;
-            }
-
-            var ret = bodyParams[0];
-            return Tuple.Create(ret.BodyAttribute.SerializationMethod, parameterList.IndexOf(ret.Parameter));
-        }
-
-        Dictionary<string, string> parseHeaders(MethodInfo methodInfo) 
-        {
-            var ret = new Dictionary<string, string>();
-
-            var declaringTypeAttributes = methodInfo.DeclaringType != null
-                ? methodInfo.DeclaringType.GetCustomAttributes(true)
-                : new Attribute[0];
-
-            // Headers set on the declaring type have to come first, 
-            // so headers set on the method can replace them. Switching
-            // the order here will break stuff.
-            var headers = declaringTypeAttributes.Concat(methodInfo.GetCustomAttributes(true))
-                .OfType<HeadersAttribute>()
-                .SelectMany(ha => ha.Headers);
-
-            foreach (var header in headers) {
-                if (string.IsNullOrWhiteSpace(header)) continue;
-
-            // NB: Silverlight doesn't have an overload for String.Split()
-            // with a count parameter, but header values can contain
-            // ':' so we have to re-join all but the first part to get the
-            // value.
-                var parts = header.Split(':');
-                ret[parts[0].Trim()] = parts.Length > 1 ? 
-                    String.Join(":", parts.Skip(1)).Trim() : null;
-            }
-
-            return ret;
-        }
-
-        Dictionary<int, string> buildHeaderParameterMap(List<ParameterInfo> parameterList) 
-        {
-            var ret = new Dictionary<int, string>();
-
-            for (int i = 0; i < parameterList.Count; i++) {
-                var header = parameterList[i].GetCustomAttributes(true)
-                    .OfType<HeaderAttribute>()
-                    .Select(ha => ha.Header)
-                    .FirstOrDefault();
-
-                if (!string.IsNullOrWhiteSpace(header)) {
-                    ret[i] = header.Trim();
-                }
-            }
-
-            return ret;
-        }
-
-        void determineReturnTypeInfo(MethodInfo methodInfo)
-        {
-            if (methodInfo.ReturnType.IsGenericType() == false) {
-                if (methodInfo.ReturnType != typeof (Task)) {
-                    goto bogusMethod;
-                }
-
-                ReturnType = methodInfo.ReturnType;
-                SerializedReturnType = typeof(void);
-                return;
-            }
-
-            var genericType = methodInfo.ReturnType.GetGenericTypeDefinition();
-            if (genericType != typeof(Task<>) && genericType != typeof(IObservable<>)) {
-                goto bogusMethod;
-            }
-
-            ReturnType = methodInfo.ReturnType;
-            SerializedReturnType = methodInfo.ReturnType.GetGenericArguments()[0];
-            return;
-
-        bogusMethod:
-            throw new ArgumentException("All REST Methods must return either Task<T> or IObservable<T>");
         }
     }
 

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -88,7 +88,7 @@ namespace Refit
         {
             var ret = new Dictionary<int, string>();
 
-            var names = RefitSettings.UriTemplateHandler.GetParameterNames(relativePath); //new UriTemplate(relativePath).GetParameterNames();
+            var names = RefitSettings.UrlTemplateHandler.GetParameterNames(relativePath); //new UriTemplate(relativePath).GetParameterNames();
             if (names.Count() == 0) {
                 return ret;
             }

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Refit
+{
+    public class RestMethodInfo
+    {
+        public string Name { get; set; }
+        public Type Type { get; set; }
+        public MethodInfo MethodInfo { get; set; }
+        public HttpMethod HttpMethod { get; set; }
+        public string RelativePath { get; set; }
+        public Dictionary<int, string> ParameterMap { get; set; }
+        public Dictionary<string, string> Headers { get; set; }
+        public Dictionary<int, string> HeaderParameterMap { get; set; }
+        public Tuple<BodySerializationMethod, int> BodyParameterInfo { get; set; }
+        public Dictionary<int, string> QueryParameterMap { get; set; }
+        public Dictionary<int, ParameterInfo> ParameterInfoMap { get; set; }
+        public Type ReturnType { get; set; }
+        public Type SerializedReturnType { get; set; }
+        public RefitSettings RefitSettings { get; set; }
+
+       
+
+        public RestMethodInfo(Type targetInterface, MethodInfo methodInfo, RefitSettings refitSettings = null)
+        {
+            RefitSettings = refitSettings ?? new RefitSettings();
+            Type = targetInterface;
+            Name = methodInfo.Name;
+            MethodInfo = methodInfo;
+
+            var hma = methodInfo.GetCustomAttributes(true)
+                .OfType<HttpMethodAttribute>()
+                .First();
+
+            HttpMethod = hma.Method;
+            RelativePath = hma.Path;
+
+            verifyUrlPathIsSane(RelativePath);
+            determineReturnTypeInfo(methodInfo);
+
+            var parameterList = methodInfo.GetParameters().ToList();
+            ParameterInfoMap = parameterList
+                .Select((parameter, index) => new { index, parameter })
+                .ToDictionary(x => x.index, x => x.parameter);
+            ParameterMap = buildParameterMap(RelativePath, parameterList);
+            BodyParameterInfo = findBodyParameter(parameterList);
+
+            Headers = parseHeaders(methodInfo);
+            HeaderParameterMap = buildHeaderParameterMap(parameterList);
+
+            QueryParameterMap = new Dictionary<int, string>();
+            for (int i=0; i < parameterList.Count; i++) {
+                if (ParameterMap.ContainsKey(i) || HeaderParameterMap.ContainsKey(i) || (BodyParameterInfo != null && BodyParameterInfo.Item2 == i)) {
+                    continue;
+                }
+
+                QueryParameterMap[i] = getUrlNameForParameter(parameterList[i]);
+            }
+        }
+
+        void verifyUrlPathIsSane(string relativePath) 
+        {
+            if (relativePath == "")
+                return;
+
+            if (!relativePath.StartsWith("/")) {
+                goto bogusPath;
+            }
+
+            var parts = relativePath.Split('/');
+            if (parts.Length == 0) {
+                goto bogusPath;
+            }
+
+            return;
+
+            bogusPath:
+            throw new ArgumentException("URL path must be of the form '/foo/bar/baz'");
+        }
+
+        Dictionary<int, string> buildParameterMap(string relativePath, List<ParameterInfo> parameterInfo)
+        {
+            var ret = new Dictionary<int, string>();
+
+            var names = RefitSettings.UriTemplateHandler.GetParameterNames(relativePath); //new UriTemplate(relativePath).GetParameterNames();
+            if (names.Count() == 0) {
+                return ret;
+            }
+
+            var paramValidationDict = parameterInfo.ToDictionary(k => getUrlNameForParameter(k).ToLowerInvariant(), v => v);
+
+            foreach (var name in names)
+            {
+                var normalizedName = name.ToLowerInvariant();
+                if (!paramValidationDict.ContainsKey(normalizedName))
+                {
+                    throw new ArgumentException(String.Format("URL has parameter {0}, but no method parameter matches", name));
+                }
+
+                ret.Add(parameterInfo.IndexOf(paramValidationDict[normalizedName]), normalizedName);
+            }
+
+            return ret;
+        }
+
+        string getUrlNameForParameter(ParameterInfo paramInfo)
+        {
+            var aliasAttr = paramInfo.GetCustomAttributes(true)
+                .OfType<AliasAsAttribute>()
+                .FirstOrDefault();
+            return aliasAttr != null ? aliasAttr.Name : paramInfo.Name;
+        }
+
+        Tuple<BodySerializationMethod, int> findBodyParameter(List<ParameterInfo> parameterList)
+        {
+            var bodyParams = parameterList
+                .Select(x => new { Parameter = x, BodyAttribute = x.GetCustomAttributes(true).OfType<BodyAttribute>().FirstOrDefault() })
+                .Where(x => x.BodyAttribute != null)
+                .ToList();
+
+            if (bodyParams.Count > 1) {
+                throw new ArgumentException("Only one parameter can be a Body parameter");
+            }
+
+            if (bodyParams.Count == 0) {
+                return null;
+            }
+
+            var ret = bodyParams[0];
+            return Tuple.Create(ret.BodyAttribute.SerializationMethod, parameterList.IndexOf(ret.Parameter));
+        }
+
+        Dictionary<string, string> parseHeaders(MethodInfo methodInfo) 
+        {
+            var ret = new Dictionary<string, string>();
+
+            var declaringTypeAttributes = methodInfo.DeclaringType != null
+                ? methodInfo.DeclaringType.GetCustomAttributes(true)
+                : new Attribute[0];
+
+            // Headers set on the declaring type have to come first, 
+            // so headers set on the method can replace them. Switching
+            // the order here will break stuff.
+            var headers = declaringTypeAttributes.Concat(methodInfo.GetCustomAttributes(true))
+                .OfType<HeadersAttribute>()
+                .SelectMany(ha => ha.Headers);
+
+            foreach (var header in headers) {
+                if (string.IsNullOrWhiteSpace(header)) continue;
+
+                // NB: Silverlight doesn't have an overload for String.Split()
+                // with a count parameter, but header values can contain
+                // ':' so we have to re-join all but the first part to get the
+                // value.
+                var parts = header.Split(':');
+                ret[parts[0].Trim()] = parts.Length > 1 ? 
+                    String.Join(":", parts.Skip(1)).Trim() : null;
+            }
+
+            return ret;
+        }
+
+        Dictionary<int, string> buildHeaderParameterMap(List<ParameterInfo> parameterList) 
+        {
+            var ret = new Dictionary<int, string>();
+
+            for (int i = 0; i < parameterList.Count; i++) {
+                var header = parameterList[i].GetCustomAttributes(true)
+                    .OfType<HeaderAttribute>()
+                    .Select(ha => ha.Header)
+                    .FirstOrDefault();
+
+                if (!string.IsNullOrWhiteSpace(header)) {
+                    ret[i] = header.Trim();
+                }
+            }
+
+            return ret;
+        }
+
+        void determineReturnTypeInfo(MethodInfo methodInfo)
+        {
+            if (methodInfo.ReturnType.IsGenericType() == false) {
+                if (methodInfo.ReturnType != typeof (Task)) {
+                    goto bogusMethod;
+                }
+
+                ReturnType = methodInfo.ReturnType;
+                SerializedReturnType = typeof(void);
+                return;
+            }
+
+            var genericType = methodInfo.ReturnType.GetGenericTypeDefinition();
+            if (genericType != typeof(Task<>) && genericType != typeof(IObservable<>)) {
+                goto bogusMethod;
+            }
+
+            ReturnType = methodInfo.ReturnType;
+            SerializedReturnType = methodInfo.ReturnType.GetGenericArguments()[0];
+            return;
+
+            bogusMethod:
+            throw new ArgumentException("All REST Methods must return either Task<T> or IObservable<T>");
+        }
+    }
+}


### PR DESCRIPTION
This PR createsa pluggable URLTemplateHandler property on RefitSettings so that RFC 6570 URI Templates can be used with a replacement URLTemplateHandler.  I did not include that new handler in this PR so as to not introduce a dependency on Tavis.UriTemplates in refit.  
If this PR is accepted then I would release a new Nuget Package that implements a handler that looks like this https://gist.github.com/darrelmiller/deff3525791be6470520
