### PR TITLE
Add nunit test adapter to VS so VSIX isn't required

### DIFF
--- a/Refit-Tests/Refit-Tests-Net45.csproj
+++ b/Refit-Tests/Refit-Tests-Net45.csproj
@@ -40,6 +40,22 @@
       <HintPath>..\packages\Rx-Testing.2.2.5\lib\net45\Microsoft.Reactive.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="nunit.core">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.util">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="ReactiveUI">
       <HintPath>..\packages\reactiveui-core.6.1.0\lib\Net45\ReactiveUI.dll</HintPath>
     </Reference>
@@ -130,7 +146,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
-    <Folder Include="Test Files\" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/Refit-Tests/packages.Refit-Tests-Net45.config
+++ b/Refit-Tests/packages.Refit-Tests-Net45.config
@@ -9,6 +9,7 @@
   <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
   <package id="Nustache" version="1.13.8.22" targetFramework="net45" />
   <package id="reactiveui-core" version="6.1.0" targetFramework="net45" />
   <package id="reactiveui-testing" version="6.1.0" targetFramework="net45" />


### PR DESCRIPTION
Adding the NUnit VS Test Adapter nuget to the test project removes the need to have the NUnit VSIX pre-installed in VS to run unit tests