### PR TITLE
Allow reserved words in param names

### DIFF
--- a/InterfaceStubGenerator/InterfaceStubGenerator.cs
+++ b/InterfaceStubGenerator/InterfaceStubGenerator.cs
@@ -116,12 +116,12 @@ namespace Refit.Generator
             ret.MethodList = interfaceTree.Members
                 .OfType<MethodDeclarationSyntax>()
                 .Select(x => new MethodTemplateInfo() {
-                    Name = x.Identifier.ValueText,
+                    Name = x.Identifier.Text,
                     ReturnType = x.ReturnType.ToString(),
                     ArgumentList = String.Join(",", x.ParameterList.Parameters
-                        .Select(y => y.Identifier.ValueText)),
+                        .Select(y => y.Identifier.Text)),
                     ArgumentListWithTypes = String.Join(",", x.ParameterList.Parameters
-                        .Select(y => String.Format("{0} {1}", y.Type.ToString(), y.Identifier.ValueText))),
+                        .Select(y => String.Format("{0} {1}", y.Type.ToString(), y.Identifier.Text))),
                     IsRefitMethod = HasRefitHttpMethodAttribute(x)
                 })
                 .ToList();

--- a/Refit-Tests/InterfaceStubGenerator.cs
+++ b/Refit-Tests/InterfaceStubGenerator.cs
@@ -136,6 +136,10 @@ namespace Refit.Tests
 
         [Get  ("spaces-shouldnt-break-me")]
         Task SpacesShouldntBreakMe();
+
+        // We don't need an explicit test for this because if it isn't supported we can't compile
+        [Get("anything")]
+        Task ReservedWordsForParameterNames(int @int, string @string, float @long);
     }
 
     public interface IAmNotARefitInterface

--- a/Refit-Tests/RefitStubs.cs
+++ b/Refit-Tests/RefitStubs.cs
@@ -149,6 +149,12 @@ namespace Refit.Tests
             return (Task) methodImpls["SpacesShouldntBreakMe"](Client, arguments);
         }
 
+        public virtual Task ReservedWordsForParameterNames(int @int,string @string,float @long)
+        {
+            var arguments = new object[] { @int,@string,@long };
+            return (Task) methodImpls["ReservedWordsForParameterNames"](Client, arguments);
+        }
+
     }
 }
 


### PR DESCRIPTION
Fixes #180 by passing through arguments exactly as specified.