### PR TITLE
Added a handful of tests for URL-encoded query string parameters

### DIFF
--- a/Refit-Tests/RequestBuilder.cs
+++ b/Refit-Tests/RequestBuilder.cs
@@ -32,6 +32,9 @@ namespace Refit.Tests
         [Get("/foo/bar/{id}")]
         Task<string> FetchSomeStuffWithAlias([AliasAs("id")] int anId);
 
+        [Get("/foo/bar/{id}")]
+        Task<string> FetchSomeStuffWithQueryParamAlias(int id, [AliasAs("q")] string search);
+
         [Get("/foo/bar/{width}x{height}")]
         Task<string> FetchAnImage(int width, int height);
 
@@ -198,6 +201,16 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void ParameterMappingWithQueryAliasSmokeTest()
+        {
+            var input = typeof(IRestMethodInfoTests);
+            var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithQueryParamAlias"));
+            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Equal("q", fixture.QueryParameterMap[1]);
+            Assert.Null(fixture.BodyParameterInfo);
+        }
+
+        [Test]
         public void ParameterMappingWithHardcodedQuerySmokeTest()
         {
             var input = typeof(IRestMethodInfoTests);

--- a/Refit-Tests/RequestBuilder.cs
+++ b/Refit-Tests/RequestBuilder.cs
@@ -211,16 +211,6 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void ParameterMappingWithQueryAliasSmokeTest()
-        {
-            var input = typeof(IRestMethodInfoTests);
-            var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "FetchSomeStuffWithQueryParamAlias"));
-            Assert.Equal("id", fixture.ParameterMap[0]);
-            Assert.Equal("q", fixture.QueryParameterMap[1]);
-            Assert.Null(fixture.BodyParameterInfo);
-        }
-
-        [Fact]
         public void ParameterMappingWithHardcodedQuerySmokeTest()
         {
             var input = typeof(IRestMethodInfoTests);

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -371,13 +371,7 @@ namespace Refit
                     return (T)(object)resp.Content;
                 }
 
-                var ms = new MemoryStream();
-                using (var fromStream = await resp.Content.ReadAsStreamAsync().ConfigureAwait(false)) {
-                    await fromStream.CopyToAsync(ms, 4096, ct).ConfigureAwait(false);
-                }
-
-                var bytes = ms.ToArray();
-                var content = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                var content = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 if (restMethod.SerializedReturnType == typeof(string)) {
                     return (T)(object)content; 


### PR DESCRIPTION
I'm investigating a case where it seems Refit is not URL-encoding query string parameters. Haven't yet gotten to the bottom of it, but thought these unit tests (which pass) wouldn't hurt to have in the code base.
