### PR TITLE
Allow setting of the content type and field name for multipart fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ At this time, multipart methods support the following parameter types:
 
 The parameter name will be used as the name of the field in the multipart data. This can be overridden with the `AliasAs` attribute.
 
-For byte array, Stream and string parameters, use `AttachmentName` parameter attribute to specify the
+For byte array and Stream parameters, use `AttachmentName` parameter attribute to specify the
 file name for the attachment. If the attachment name is not specified, the name will be used. For `FileInfo` parameters, `FileInfo.Name` will be used.
 
 Use `AttachmentContentType` attribute to specify the content type of an attachment. This should be applied to the parameter, not the method.

--- a/README.md
+++ b/README.md
@@ -409,15 +409,19 @@ At this time, multipart methods support the following parameter types:
  - Stream
  - FileInfo
 
-For byte array and Stream parameters, use `AttachmentName` parameter attribute to specify the
-name for the attachment. For `FileInfo` parameters, the file name will be used.
+The parameter name will be used as the name of the field in the multipart data. This can be overridden with the `AliasAs` attribute.
+
+For byte array, Stream and string parameters, use `AttachmentName` parameter attribute to specify the
+file name for the attachment. If the attachment name is not specified, the name will be used. For `FileInfo` parameters, `FileInfo.Name` will be used.
+
+Use `AttachmentContentType` attribute to specify the content type of an attachment. This should be applied to the parameter, not the method.
 
 ```csharp
 public interface ISomeApi
 {
     [Multipart]
     [Post("/users/{id}/photo")]
-    Task UploadPhoto(int id, [AttachmentName("photo.jpg")] Stream stream);
+    Task UploadPhoto(int id, [AliasAs("myPhoto")][AttachmentName("photo.jpg")][AttachmentContentType("image/jpeg")] Stream stream);
 }
 ```
 

--- a/Refit-Tests/MultipartTests.cs
+++ b/Refit-Tests/MultipartTests.cs
@@ -21,7 +21,7 @@ namespace Refit.Tests
 
         [Multipart]
         [Post("/")]
-        Task<HttpResponseMessage> UploadString([AliasAs("SomeStringAlias")][AttachmentName("test.text")][AttachmentContentType("text/placebo")]string someString);
+        Task<HttpResponseMessage> UploadString([AliasAs("SomeStringAlias")]string someString);
 
         [Multipart]
         [Post("/")]

--- a/Refit-Tests/MultipartTests.cs
+++ b/Refit-Tests/MultipartTests.cs
@@ -13,19 +13,19 @@ namespace Refit.Tests
     {
         [Multipart]
         [Post("/")]
-        Task<HttpResponseMessage> UploadStream([AttachmentName("test.pdf")] Stream stream);
+        Task<HttpResponseMessage> UploadStream([AttachmentName("test.pdf")][AttachmentContentType("application/pdf")] Stream stream);
 
         [Multipart]
         [Post("/")]
-        Task<HttpResponseMessage> UploadBytes([AttachmentName("test.pdf")] byte[] bytes);
+        Task<HttpResponseMessage> UploadBytes([AttachmentName("test.pdf")][AttachmentContentType("application/pdf")] byte[] bytes);
 
         [Multipart]
         [Post("/")]
-        Task<HttpResponseMessage> UploadString(string someString);
+        Task<HttpResponseMessage> UploadString([AliasAs("SomeStringAlias")][AttachmentName("test.text")][AttachmentContentType("text/placebo")]string someString);
 
         [Multipart]
         [Post("/")]
-        Task<HttpResponseMessage> UploadFileInfo(FileInfo fileInfo);
+        Task<HttpResponseMessage> UploadFileInfo([AttachmentContentType("application/pdf")]FileInfo fileInfo);
     }
 
     [TestFixture]

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -148,4 +148,14 @@ namespace Refit
         {
         }
     }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class AttachmentContentTypeAttribute : Attribute
+    {
+        public string MediaType { get; protected set; }
+        public AttachmentContentTypeAttribute(string mediaType)
+        {
+            MediaType = mediaType;
+        }
+    }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -222,12 +222,7 @@ namespace Refit
             }
              
             if (stringValue != null) {
-                var stringContent = new StringContent(stringValue);
-                if (!string.IsNullOrEmpty(mediaType))
-                {
-                    stringContent.Headers.ContentType = new MediaTypeHeaderValue(mediaType);
-                }
-                multiPartContent.Add(stringContent, itemName, fileName);
+                multiPartContent.Add(new StringContent(stringValue), itemName);
                 return;
             }
 


### PR DESCRIPTION
Allows setting of the content type for multipart fields

Allow setting of the file name separate to the field name for multipart fields. The parameter name or AliasAs attribute now define the field name. This has the potential to break compatibility with applications which depend on the AttachmentName to set the field name. The alternative is to ignore the parameter name and only rely on AliasAs however this would result in inconsistent API design

Relates to: Setting multipart stream field name #160 
