### PR TITLE
Allow post-processing of HttpResponseMessages

### DIFF
--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -377,7 +377,16 @@ namespace Refit
                     return (T)(object)content; 
                 }
 
-                return JsonConvert.DeserializeObject<T>(content, settings.JsonSerializerSettings);
+                var deserializedObject = JsonConvert.DeserializeObject<T>(content, settings.JsonSerializerSettings);
+
+                // enable message post-processor functionality on resulting object if implements interface,
+                // so it is possible to access http response message even when resulting type
+                // of the call is something more specific (e.g. to allow processing of response headers)
+                if (deserializedObject is IHttpResponseMessagePostProcessor) {
+                    (deserializedObject as IHttpResponseMessagePostProcessor).PostProcessHttpResponseMessage(resp);
+                }
+
+                return deserializedObject;
             };
         }
 

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -15,6 +15,11 @@ namespace Refit
         T For<T>(HttpClient client);
     }
 
+    public interface IHttpResponseMessagePostProcessor
+    {
+        void PostProcessHttpResponseMessage(HttpResponseMessage message);
+    }
+
     public static class RestService
     {
         public static T For<T>(HttpClient client, RefitSettings settings)


### PR DESCRIPTION
Sometimes, it is beneficiary to be able to process the `HttpResponseMessage` even when the return type of API call defines more specific class, e.g. because an API you are interfacing with is defining some important run-time state in response header and there was no other way to access such information than by explicitly returning `HttpResponseMessage` and then taking care of `DeserializeObject` manually. 

That brings two nasty issues:
- the interface is not as clear, as it could be - the result value is replaced by `HttpResponseMessage`
- it is error prone and more complicated to do so 

My proposed solution introduces `IHttpResponseMessagePostProcessor` with only a single method void `PostProcessHttpResponseMessage(HttpResponseMessage message)`, that in style of Spring/NET `IContextAware` allows implementing entity to work with the message. There is no cascading to related entities, only a deserialized object is checked, so the performance is not much affected and it is called post-processor to avoid clients thinking they should store the message in their structure somewhere.

I hope you will not consider it edge case and will merge it to the main branch.