### PR TITLE
support for a second GetToken callback that enables refreshing the token in unexpected cases

### DIFF
--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -16,6 +16,7 @@ namespace Refit
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public Func<Task<string>> AuthorizationHeaderValueGetter { get; set; }
+        public Func<Task<string>> AuthorizationHeaderRefreshedValueGetter { get; set; }
         public Func<HttpMessageHandler> HttpMessageHandlerFactory { get; set; }
     }
 

--- a/Refit/RestService.cs
+++ b/Refit/RestService.cs
@@ -53,7 +53,7 @@ namespace Refit
                 }
 
                 if (settings.AuthorizationHeaderValueGetter != null) {
-                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, innerHandler);
+                    innerHandler = new AuthenticatedHttpClientHandler(settings.AuthorizationHeaderValueGetter, settings.AuthorizationHeaderRefreshedValueGetter, innerHandler);
                 }
             }
 


### PR DESCRIPTION
Whenever there is an unexpected 401 because of an invalid token the second callback (if provided) gets called so that the Refit client is able to refresh the token on demand before the overall call results in an Unauthorized exception.
Normally the expiration of a token is tracked on the client side and a refreshed token gets fetched when needed.
This new functionality allows to wire up a fallback logic that refreshes the token whenever the expiration in reality doesn't match the calculated one (e.g. the user changes the system time)