### PR TITLE
Use JsonPropertyAttribute for aliasing form parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,23 @@ var measurement = new Measurement {
 await api.Collect(measurement);
 ``` 
 
+If you have a type that has `[JsonProperty(PropertyName)]` attributes setting property aliases, Refit will use those too (`[AliasAs]` will take precedence where you have both). 
+This means that the following type will serialize as `one=value1&two=value2`:
+
+```csharp
+
+public class SomeObject
+{
+    [JsonProperty(PropertyName = "one")]
+    public string FirstProperty { get; set; }
+
+    [JsonProperty(PropertyName = "notTwo")]
+    [AliasAs("two")]
+    public string SecondProperty { get; set; }
+}
+
+```
+
 ### Setting request headers
 
 #### Static headers

--- a/Refit.Tests/FormValueDictionaryTests.cs
+++ b/Refit.Tests/FormValueDictionaryTests.cs
@@ -1,0 +1,138 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Refit.Tests
+{
+    public class FormValueDictionaryTests
+    {
+        [Fact]
+        public void EmptyIfNullPassedIn()
+        {
+            var target = new FormValueDictionary(null);
+            Assert.Empty(target);
+        }
+
+
+        [Fact]
+        public void LoadsFromDictionary()
+        {
+            var source = new Dictionary<string, string> {
+                { "foo", "bar" },
+                { "xyz", "123" }
+            };
+
+            var target = new FormValueDictionary(source);
+
+            Assert.Equal(source, target);
+        }
+
+        [Fact]
+        public void LoadsFromObject()
+        {
+            var source = new ObjectTestClass
+            {
+                A = "1",
+                B = "2"
+            };
+            var expected = new Dictionary<string, string>
+            {
+                { "A", "1" },
+                { "B", "2" },
+                { "C", "" }
+            };
+
+            var actual = new FormValueDictionary(source);
+
+            Assert.Equal(expected, actual);
+        }
+
+        public class ObjectTestClass
+        {
+            public string A { get; set; }
+            public string B { get; set; }
+            public string C { get; set; }
+        }
+
+        [Fact]
+        public void LoadsFromAnonymousType()
+        {
+            var source = new
+            {
+                foo = "bar",
+                xyz = 123
+            };
+
+            var expected = new Dictionary<string, string>
+            {
+                { "foo", "bar" },
+                { "xyz", "123" }
+            };
+
+            var actual = new FormValueDictionary(source);
+
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void UsesAliasAsAttribute()
+        {
+            var source = new AliasingTestClass
+            {
+                Foo = "abc"
+            };
+
+            var target = new FormValueDictionary(source);
+
+            Assert.DoesNotContain("Foo", target.Keys);
+            Assert.Contains("f", target.Keys);
+            Assert.Equal("abc", target["f"]);
+        }
+
+        [Fact]
+        public void UsesJsonPropertyAttribute()
+        {
+            var source = new AliasingTestClass
+            {
+                Bar = "xyz"
+            };
+
+            var target = new FormValueDictionary(source);
+
+            Assert.DoesNotContain("Bar", target.Keys);
+            Assert.Contains("b", target.Keys);
+            Assert.Equal("xyz", target["b"]);
+        }
+
+        [Fact]
+        public void GivesPrecedenceToAliasAs()
+        {
+            var source = new AliasingTestClass
+            {
+                Baz = "123"
+            };
+
+            var target = new FormValueDictionary(source);
+
+            Assert.DoesNotContain("Bar", target.Keys);
+            Assert.DoesNotContain("z", target.Keys);
+            Assert.Contains("a", target.Keys);
+            Assert.Equal("123", target["a"]);
+        }
+
+
+        public class AliasingTestClass
+        {
+            [AliasAs("f")]
+            public string Foo { get; set; }
+
+            [JsonProperty(PropertyName = "b")]
+            public string Bar { get; set; }
+
+            [AliasAs("a")]
+            [JsonProperty(PropertyName = "z")]
+            public string Baz { get; set; }
+        }
+    }
+}

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -104,7 +104,7 @@ namespace Refit
         public string Name { get; protected set; }
         public AliasAsAttribute(string name)
         {
-            this.Name = name;
+            Name = name;
         }
     }
 

--- a/Refit/FormValueDictionary.cs
+++ b/Refit/FormValueDictionary.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Newtonsoft.Json;
 
 namespace Refit
 {
@@ -15,10 +16,8 @@ namespace Refit
         {
             if (source == null) return;
 
-            if (source is IDictionary dictionary)
-            {
-                foreach (var key in dictionary.Keys)
-                {
+            if (source is IDictionary dictionary) {
+                foreach (var key in dictionary.Keys) {
                     Add(key.ToString(), string.Format("{0}", dictionary[key]));
                 }
 
@@ -47,10 +46,13 @@ namespace Refit
 
         string GetFieldNameForProperty(PropertyInfo propertyInfo)
         {
-            var aliasAttr = propertyInfo.GetCustomAttributes(true)
-                .OfType<AliasAsAttribute>()
-                .FirstOrDefault();
-            return aliasAttr != null ? aliasAttr.Name : propertyInfo.Name;
+            return propertyInfo.GetCustomAttributes<AliasAsAttribute>(true)
+                .Select(a => a.Name)
+                .FirstOrDefault()
+                ?? propertyInfo.GetCustomAttributes<JsonPropertyAttribute>(true)
+                .Select(a => a.PropertyName)
+                .FirstOrDefault()
+                ?? propertyInfo.Name;
         }
     }
 }


### PR DESCRIPTION
This adds support for Json.NET's `JsonPropertyAttribute` if present on a
property when using it to generate a request as a form post.

If both `AliasAsAttribute` and `JsonPropertyAttribute` are present,
`AliasAsAttribute` takes precedence.

I also added some tests for `FormValueDictionary`.

Fixes #330.