### PR TITLE
Added feature for 'DynamicQueryParameters'

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,39 @@ GroupList(4, "desc");
 >>> "/group/4/users?sort=desc"
 ```
 
+If you specify an `object` as query parameter, all public properties which are not null, where used as query parameters. 
+Use the `Query` attribute the change the behavior of 'flatten' your query parameter object. If using this Attribute you can specify values for the Delimiter and the Prefix which are used for 'flatten' the object.
+
+```csharp
+public class MyQueryParams
+{
+    [AliasAs("order")]
+    public string SortOrder { get; set; }
+
+    public int Limit { get; set; }
+}
+
+
+[Get("/group/{id}/users")]
+Task<List<User>> GroupList([AliasAs("id")] int groupId, MyQueryParams params);
+
+[Get("/group/{id}/users")]
+Task<List<User>> GroupListWithAttribute([AliasAs("id")] int groupId, [Query(".","search")] MyQueryParams params);
+
+
+params.SortOrder = "desc";
+params.Limit = 10;
+
+GroupList(4, params)
+>>> "/group/4/users?order=desc&Limit=10"
+
+GroupListWithAttribute(4, params)
+>>> "/group/4/users?search.order=desc&search.Limit=10"
+```
+
+A similar behavior exists if using a Dictionary, but without the advantages of the `AliasAs` attributes and of course no intellisense and/or type safety.
+
+
 ### Body content
 
 One of the parameters in your method can be used as the body, by using the

--- a/Refit.Tests/MyQueryParams.cs
+++ b/Refit.Tests/MyQueryParams.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Refit.Tests
+{
+    public class MySimpleQueryParams
+    {
+        public string FirstName { get; set; }
+
+        [AliasAs("lName")]
+        public string LastName { get; set; }
+    }
+
+    public class MyComplexQueryParams
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        [AliasAs("Addr")]
+        public Address Address { get; set; } = new Address();
+
+        public Dictionary<string, object> MetaData { get; set; } = new Dictionary<string, object>();
+
+        public List<object> Other { get; set; } = new List<object>();
+    }
+
+    public class Address
+    {
+        [AliasAs("Zip")]
+        public int Postcode { get; set; }
+        public string Street { get; set; }
+    }
+}

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -148,4 +148,27 @@ namespace Refit
         {
         }
     }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class QueryAttribute : Attribute
+    {
+        public string Delimiter { get; protected set; } = ".";
+        public string Prefix { get; protected set; }
+
+        public QueryAttribute()
+        {
+        }
+
+        public QueryAttribute(string delimiter)
+        {
+            Delimiter = delimiter;
+        }
+
+        public QueryAttribute(string delimiter, string prefix)
+        {
+            Delimiter = delimiter;
+            Prefix = prefix;
+        }
+
+    }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -139,14 +139,10 @@ namespace Refit
                     // a multipart method, add the parameter to the query string
                     if (!restMethod.IsMultipart) {
                         var attr = restMethod.ParameterInfoMap[i].GetCustomAttribute<QueryAttribute>() ?? new QueryAttribute();
-                        if (DoNotConvertToQueryMap(paramList[i]))
-                        {
+                        if (DoNotConvertToQueryMap(paramList[i])) {
                             queryParamsToAdd.Add(new KeyValuePair<string, string>(restMethod.QueryParameterMap[i], settings.UrlParameterFormatter.Format(paramList[i], restMethod.ParameterInfoMap[i])));
-                        }
-                        else
-                        {
-                            foreach (var kvp in BuildQueryMap(paramList[i], attr.Delimiter))
-                            {
+                        } else {
+                            foreach (var kvp in BuildQueryMap(paramList[i], attr.Delimiter)) {
                                 var path = !String.IsNullOrWhiteSpace(attr.Prefix) ? $"{attr.Prefix}{attr.Delimiter}{kvp.Key}" : kvp.Key;
                                 queryParamsToAdd.Add(new KeyValuePair<string, string>(path, settings.UrlParameterFormatter.Format(kvp.Value, restMethod.ParameterInfoMap[i])));
                             }
@@ -221,18 +217,14 @@ namespace Refit
                 // parameters as well as add the parameterized ones.
                 var uri = new UriBuilder(new Uri(new Uri("http://api"), urlTarget));
                 var query = HttpUtility.ParseQueryString(uri.Query ?? "");
-                foreach (string key in query.AllKeys)
-                {
+                foreach (string key in query.AllKeys) {
                     queryParamsToAdd.Insert(0, new KeyValuePair<string, string>(key, query[key]));
                 }
 
-                if (queryParamsToAdd.Any())
-                {
+                if (queryParamsToAdd.Any()) {
                     var pairs = queryParamsToAdd.Select(x => HttpUtility.UrlEncode(x.Key) + "=" + HttpUtility.UrlEncode(x.Value));
                     uri.Query = string.Join("&", pairs);
-                }
-                else
-                {
+                } else {
                     uri.Query = null;
                 }
 
@@ -444,15 +436,15 @@ namespace Refit
 
         static bool DoNotConvertToQueryMap(object value)
         {
-
-            if (value == null) return false;
+            if (value == null)
+                return false;
 
             var type = value.GetType().GetTypeInfo();
 
-            if (type.IsPrimitive) return true;
+            if (type.IsPrimitive)
+                return true;
 
-            switch (value)
-            {
+            switch (value) {
                 case String str:
                 case DateTime dt:
                 case TimeSpan ts:
@@ -466,7 +458,8 @@ namespace Refit
 
         List<KeyValuePair<string, object>> BuildQueryMap(object @object, string delimiter = null)
         {
-            if (@object is IDictionary idictionary) return BuildQueryMap(idictionary, delimiter);
+            if (@object is IDictionary idictionary)
+                return BuildQueryMap(idictionary, delimiter);
 
             var kvps = new List<KeyValuePair<string, object>>();
 
@@ -482,10 +475,10 @@ namespace Refit
                 var key = propertyInfo.Name;
 
                 var aliasAttribute = propertyInfo.GetCustomAttribute<AliasAsAttribute>();
-                if (aliasAttribute != null) key = aliasAttribute.Name;
+                if (aliasAttribute != null)
+                    key = aliasAttribute.Name;
 
-                if (DoNotConvertToQueryMap(obj))
-                {
+                if (DoNotConvertToQueryMap(obj)) {
                     kvps.Add(new KeyValuePair<string, object>(key, obj));
                     continue;
                 }
@@ -493,22 +486,19 @@ namespace Refit
                 switch (obj)
                 {
                     case IDictionary idict:
-                        foreach (var keyValuePair in BuildQueryMap(idict, delimiter))
-                        {
+                        foreach (var keyValuePair in BuildQueryMap(idict, delimiter)) {
                             kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                         }
                         break;
 
                     case IEnumerable ienu:
-                        foreach (var o in ienu)
-                        {
+                        foreach (var o in ienu) {
                             kvps.Add(new KeyValuePair<string, object>(key, o));
                         }
                         break;
 
                     default:
-                        foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
-                        {
+                        foreach (var keyValuePair in BuildQueryMap(obj, delimiter)) {
                             kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                         }
                         break;
@@ -522,19 +512,15 @@ namespace Refit
             var kvps = new List<KeyValuePair<string, object>>();
 
             var props = dictionary.Keys;
-            foreach (string key in props)
-            {
+            foreach (string key in props) {
                 var obj = dictionary[key];
-                if (obj == null) continue;
+                if (obj == null)
+                    continue;
 
-                if (DoNotConvertToQueryMap(obj))
-                {
+                if (DoNotConvertToQueryMap(obj)) {
                     kvps.Add(new KeyValuePair<string, object>(key, obj));
-                }
-                else
-                {
-                    foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
-                    {
+                } else {
+                    foreach (var keyValuePair in BuildQueryMap(obj, delimiter)) {
                         kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                     }
                 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -145,7 +145,7 @@ namespace Refit
                         }
                         else
                         {
-                            foreach (var kvp in ToQueryMap(paramList[i], attr.Delimiter))
+                            foreach (var kvp in BuildQueryMap(paramList[i], attr.Delimiter))
                             {
                                 var path = !String.IsNullOrWhiteSpace(attr.Prefix) ? $"{attr.Prefix}{attr.Delimiter}{kvp.Key}" : kvp.Key;
                                 queryParamsToAdd.Add(new KeyValuePair<string, string>(path, settings.UrlParameterFormatter.Format(kvp.Value, restMethod.ParameterInfoMap[i])));
@@ -442,16 +442,14 @@ namespace Refit
             };
         }
 
-        public static bool DoNotConvertToQueryMap(object value)
+        static bool DoNotConvertToQueryMap(object value)
         {
 
-            if (value == null)
-                return false;
+            if (value == null) return false;
 
             var type = value.GetType().GetTypeInfo();
 
-            if (type.IsPrimitive)
-                return true;
+            if (type.IsPrimitive) return true;
 
             switch (value)
             {
@@ -466,15 +464,15 @@ namespace Refit
             return false;
         }
 
-        private List<KeyValuePair<string, object>> ToQueryMap(object @object, string delimiter = null)
+        List<KeyValuePair<string, object>> BuildQueryMap(object @object, string delimiter = null)
         {
-            if (@object is IDictionary idictionary)
-                return ToQueryMap(idictionary, delimiter);
+            if (@object is IDictionary idictionary) return BuildQueryMap(idictionary, delimiter);
 
             var kvps = new List<KeyValuePair<string, object>>();
 
             var bindingFlags = System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public;
             var props = @object.GetType().GetProperties(bindingFlags);
+
             foreach (var propertyInfo in props)
             {
                 var obj = propertyInfo.GetValue(@object);
@@ -484,8 +482,7 @@ namespace Refit
                 var key = propertyInfo.Name;
 
                 var aliasAttribute = propertyInfo.GetCustomAttribute<AliasAsAttribute>();
-                if (aliasAttribute != null)
-                    key = aliasAttribute.Name;
+                if (aliasAttribute != null) key = aliasAttribute.Name;
 
                 if (DoNotConvertToQueryMap(obj))
                 {
@@ -496,7 +493,7 @@ namespace Refit
                 switch (obj)
                 {
                     case IDictionary idict:
-                        foreach (var keyValuePair in ToQueryMap(idict, delimiter))
+                        foreach (var keyValuePair in BuildQueryMap(idict, delimiter))
                         {
                             kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                         }
@@ -510,7 +507,7 @@ namespace Refit
                         break;
 
                     default:
-                        foreach (var keyValuePair in ToQueryMap(obj, delimiter))
+                        foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
                         {
                             kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                         }
@@ -520,7 +517,7 @@ namespace Refit
             return kvps;
         }
 
-        private List<KeyValuePair<string, object>> ToQueryMap(IDictionary dictionary, string delimiter = null)
+        List<KeyValuePair<string, object>> BuildQueryMap(IDictionary dictionary, string delimiter = null)
         {
             var kvps = new List<KeyValuePair<string, object>>();
 
@@ -528,8 +525,7 @@ namespace Refit
             foreach (string key in props)
             {
                 var obj = dictionary[key];
-                if (obj == null)
-                    continue;
+                if (obj == null) continue;
 
                 if (DoNotConvertToQueryMap(obj))
                 {
@@ -537,7 +533,7 @@ namespace Refit
                 }
                 else
                 {
-                    foreach (var keyValuePair in ToQueryMap(obj, delimiter))
+                    foreach (var keyValuePair in BuildQueryMap(obj, delimiter))
                     {
                         kvps.Add(new KeyValuePair<string, object>($"{key}{delimiter}{keyValuePair.Key}", keyValuePair.Value));
                     }


### PR DESCRIPTION
I have the need like in #315 to use an Object or Dictionary as Queryparamters.

With this Pull Request this is now possible

```
public class MySimpleQueryParams
{
    public string FirstName { get; set; }

    [AliasAs("lName")]
    public string LastName { get; set; }
}

public class MyComplexQueryParams
{
    public string FirstName { get; set; }

    public string LastName { get; set; }

    [AliasAs("Addr")]
    public Address Address { get; set; } = new Address();

    public Dictionary<string, object> MetaData { get; set; } = new Dictionary<string, object>();

    public List<object> Other { get; set; } = new List<object>();
}

public class Address
{
    [AliasAs("Zip")]
    public int Postcode { get; set; }
    public string Street { get; set; }
}
```  
--------------------
```
public interface IHttpBinApi<TResponse, in TParam, in THeader>
    where TResponse : class
    where THeader : struct
{
    [Get("")]
    Task<TResponse> Get(TParam param, [Header("X-Refit")] THeader header);

    [Get("/get?hardcoded=true")]
    Task<TResponse> GetQuery([Query("_")]TParam param);

    [Get("")]
    Task<TResponse> GetQueryWithIncludeParameterName([Query(".", "search")]TParam param);
}
```  
--------------------
```
[Fact]
public async Task SimpleDynamicQueryparametersTest()
{

    var myParams = new MySimpleQueryParams();
    myParams.FirstName = "John";
    myParams.LastName = "Rambo";

    var fixture = RestService.For<IHttpBinApi<HttpBinGet, MySimpleQueryParams, int>>("https://httpbin.org/get");

    var resp = await fixture.Get(myParams, 99);

    Assert.Equal("John", resp.Args["FirstName"]);
    Assert.Equal("Rambo", resp.Args["lName"]);
}
```
creates following Url: "https://httpbin.org/get?hardcoded=true&FirstName=John&lName=Rambo"


If have created a new Attribute -> QueryAttribute, with the Properties Delimiter and Prefix.
If you do not specifiy the Attribute on the Parameter, the Default Values will be used.
Delimiter = "."
Prefix = null

This is needed for Nested Objects or Dictionaries.
Nested Objects or Dictionaries are "flatted" ->

```
[Fact]
public async Task ComplexDynamicQueryparametersTestWithIncludeParameterName()
{

    var myParams = new MyComplexQueryParams();
    myParams.FirstName = "John";
    myParams.LastName = "Rambo";
    myParams.Address.Postcode = 9999;
    myParams.Address.Street = "HomeStreet 99";

    var fixture = RestService.For<IHttpBinApi<HttpBinGet, MyComplexQueryParams, int>>("https://httpbin.org/get");

    var resp = await fixture.GetQueryWithIncludeParameterName(myParams);

    Assert.Equal("John", resp.Args["search.FirstName"]);
    Assert.Equal("Rambo", resp.Args["search.LastName"]);
    Assert.Equal("9999", resp.Args["search.Addr.Zip"]);
}
```
In combination with Delimiter and Prefix following Url will be created:
https://httpbin.org/get?search.FirstName=John&search.LastName=Rambo&search.Addr.Zip=9999&search.Addr.Street=HomeStreet%2099 

In the Class you can use the AliasAs Attribute for overriding the "Key" of the Queryparameter.

Thats very usefull when you need QueryParameters like "search.Firstname" "search.Lastname"...
So you can create a Class with all possible search parameters. All Properties wich are not null will then be in the Queryparameters. With or without Prefix and/or Delimiter.

If do not like to create a whole Class you can use a simple Dictionary instead.
But this doesn't give you intellisense or any other Class features like Typesafe or the AliasAs Attribute. 

The Second thing i have changed is the format of Arrays as Queryparameters.
Arrays Parameters are now formated as value=1&value=2&value=3.
As far i have found, this is the most used way to specifiy Arrays as Queryparameters...

