### PR TITLE
Skip null urlencoded form

### DIFF
--- a/Refit.Tests/FormValueDictionaryTests.cs
+++ b/Refit.Tests/FormValueDictionaryTests.cs
@@ -6,10 +6,12 @@ namespace Refit.Tests
 {
     public class FormValueDictionaryTests
     {
+        readonly RefitSettings settings = new RefitSettings();
+
         [Fact]
         public void EmptyIfNullPassedIn()
         {
-            var target = new FormValueDictionary(null);
+            var target = new FormValueDictionary(null, settings);
             Assert.Empty(target);
         }
 
@@ -22,7 +24,7 @@ namespace Refit.Tests
                 { "xyz", "123" }
             };
 
-            var target = new FormValueDictionary(source);
+            var target = new FormValueDictionary(source, settings);
 
             Assert.Equal(source, target);
         }
@@ -39,10 +41,9 @@ namespace Refit.Tests
             {
                 { "A", "1" },
                 { "B", "2" },
-                { "C", "" }
             };
 
-            var actual = new FormValueDictionary(source);
+            var actual = new FormValueDictionary(source, settings);
 
             Assert.Equal(expected, actual);
         }
@@ -69,7 +70,7 @@ namespace Refit.Tests
                 { "xyz", "123" }
             };
 
-            var actual = new FormValueDictionary(source);
+            var actual = new FormValueDictionary(source, settings);
 
 
             Assert.Equal(expected, actual);
@@ -83,7 +84,7 @@ namespace Refit.Tests
                 Foo = "abc"
             };
 
-            var target = new FormValueDictionary(source);
+            var target = new FormValueDictionary(source, settings);
 
             Assert.DoesNotContain("Foo", target.Keys);
             Assert.Contains("f", target.Keys);
@@ -98,7 +99,7 @@ namespace Refit.Tests
                 Bar = "xyz"
             };
 
-            var target = new FormValueDictionary(source);
+            var target = new FormValueDictionary(source, settings);
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.Contains("b", target.Keys);
@@ -113,7 +114,7 @@ namespace Refit.Tests
                 Baz = "123"
             };
 
-            var target = new FormValueDictionary(source);
+            var target = new FormValueDictionary(source, settings);
 
             Assert.DoesNotContain("Bar", target.Keys);
             Assert.DoesNotContain("z", target.Keys);
@@ -121,6 +122,20 @@ namespace Refit.Tests
             Assert.Equal("123", target["a"]);
         }
 
+
+        [Fact]
+        public void SkipsNullValuesFromDictionary()
+        {
+            var source = new Dictionary<string, string> {
+                { "foo", "bar" },
+                { "xyz", null }
+            };
+
+            var target = new FormValueDictionary(source, settings);
+
+            Assert.Single(target);
+            Assert.Contains("foo", target.Keys);
+        }
 
         public class AliasingTestClass
         {

--- a/Refit.Tests/FormValueDictionaryTests.cs
+++ b/Refit.Tests/FormValueDictionaryTests.cs
@@ -107,6 +107,22 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void UsesQueryPropertyAttribute()
+        {
+            var source = new AliasingTestClass
+            {
+                Frob = 4
+            };
+
+            var target = new FormValueDictionary(source, settings);
+
+            Assert.DoesNotContain("Bar", target.Keys);
+            Assert.Contains("prefix-fr", target.Keys);
+            Assert.Equal("4.0", target["prefix-fr"]);
+        }
+
+
+        [Fact]
         public void GivesPrecedenceToAliasAs()
         {
             var source = new AliasingTestClass
@@ -148,6 +164,11 @@ namespace Refit.Tests
             [AliasAs("a")]
             [JsonProperty(PropertyName = "z")]
             public string Baz { get; set; }
+
+
+            [Query("-", "prefix", "0.0")]
+            [AliasAs("fr")]
+            public int? Frob { get; set; }
         }
     }
 }

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -419,6 +419,9 @@ namespace Refit.Tests
 
         [Patch("/foo/bar/{id}")]
         IObservable<string> PatchSomething(int id, [Body] string someAttribute);
+
+        [Get("/foo/bar/{id}")]
+        Task<string> FetchSomeStuffWithQueryFormat([Query(Format= "0.0")] int id);
     }
 
     interface ICancellableMethods
@@ -622,6 +625,17 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
             Assert.Equal("/foo/bar/6?baz=bamf&search_for=foo", uri.PathAndQuery);
+        }
+
+        [Fact]
+        public void QueryParamShouldFormat()
+        {
+            var fixture = new RequestBuilderImplementation(typeof(IDummyHttpApi));
+            var factory = fixture.BuildRequestFactoryForMethod("FetchSomeStuffWithQueryFormat");
+            var output = factory(new object[] { 6 });
+
+            var uri = new Uri(new Uri("http://api"), output.RequestUri);
+            Assert.Equal("/foo/bar/6.0", uri.PathAndQuery);
         }
 
         [Fact]

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -873,7 +873,7 @@ namespace Refit.Tests
                     new {
                         Foo = "Something", 
                         Bar = 100, 
-                        Baz = default(string)
+                        Baz = "" // explicitly use blank to preserve value that would be stripped if null
                     }
                 });
 

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -165,7 +165,8 @@ namespace Refit
             : base("Authorization: " + scheme) { }
     }
 
-    [AttributeUsage(AttributeTargets.Parameter)]
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)] // Property is to allow for form url encoded data
+
     public class QueryAttribute : Attribute
     {
         public QueryAttribute() { }
@@ -181,7 +182,16 @@ namespace Refit
             Prefix = prefix;
         }
 
+        public QueryAttribute(string delimiter, string prefix, string format)
+        {
+            Delimiter = delimiter;
+            Prefix = prefix;
+            Format = format;
+        }
+
         public string Delimiter { get; protected set; } = ".";
         public string Prefix { get; protected set; }
+
+        public string Format { get; set; }
     }
 }

--- a/Refit/FormValueDictionary.cs
+++ b/Refit/FormValueDictionary.cs
@@ -13,7 +13,7 @@ namespace Refit
         static readonly Dictionary<Type, PropertyInfo[]> propertyCache
             = new Dictionary<Type, PropertyInfo[]>();
 
-        public FormValueDictionary(object source)
+        public FormValueDictionary(object source, RefitSettings settings)
         {
             if (source == null) return;
 
@@ -21,7 +21,11 @@ namespace Refit
             {
                 foreach (var key in dictionary.Keys)
                 {
-                    Add(key.ToString(), $"{dictionary[key]}");
+                    var value = dictionary[key];
+                    if (value != null && key != null)
+                    {
+                        Add(key.ToString(),  settings.UrlParameterFormatter.Format(value, null));
+                    }
                 }
 
                 return;
@@ -38,7 +42,11 @@ namespace Refit
 
                 foreach (var property in propertyCache[type])
                 {
-                    Add(GetFieldNameForProperty(property), $"{property.GetValue(source, null)}");
+                    var value = property.GetValue(source, null);
+                    if (value != null)
+                    {
+                        Add(GetFieldNameForProperty(property), settings.UrlParameterFormatter.Format(value, null));
+                    }
                 }
             }
         }

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -39,7 +39,16 @@ namespace Refit
     {
         public virtual string Format(object parameterValue, ParameterInfo parameterInfo)
         {
-            return parameterValue == null ? null : string.Format(CultureInfo.InvariantCulture, "{0}", parameterValue);
+            // See if we have a format
+            var formatString = parameterInfo.GetCustomAttribute<QueryAttribute>(true)?.Format;
+
+            return parameterValue == null
+                       ? null
+                       : string.Format(CultureInfo.InvariantCulture,
+                                       string.IsNullOrWhiteSpace(formatString)
+                                           ? "{0}"
+                                           : $"{{0:{formatString}}}",
+                                       parameterValue);
         }
     }
 

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -14,6 +14,7 @@ namespace Refit
         public RefitSettings()
         {
             UrlParameterFormatter = new DefaultUrlParameterFormatter();
+            FormUrlEncodedParameterFormatter = new DefaultFormUrlEncodedParameterFormatter();
         }
 
         public Func<Task<string>> AuthorizationHeaderValueGetter { get; set; }
@@ -21,6 +22,7 @@ namespace Refit
 
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
+        public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
     }
 
     public interface IUrlParameterFormatter
@@ -28,11 +30,30 @@ namespace Refit
         string Format(object value, ParameterInfo parameterInfo);
     }
 
+    public interface IFormUrlEncodedParameterFormatter
+    {
+        string Format(object value, string formatString);
+    }
+
     public class DefaultUrlParameterFormatter : IUrlParameterFormatter
     {
         public virtual string Format(object parameterValue, ParameterInfo parameterInfo)
         {
             return parameterValue == null ? null : string.Format(CultureInfo.InvariantCulture, "{0}", parameterValue);
+        }
+    }
+
+    public class DefaultFormUrlEncodedParameterFormatter : IFormUrlEncodedParameterFormatter
+    {
+        public virtual string Format(object parameterValue, string formatString)
+        {
+            return parameterValue == null 
+                       ? null 
+                       : string.Format(CultureInfo.InvariantCulture, 
+                                       string.IsNullOrWhiteSpace(formatString)
+                                                                     ? "{0}"
+                                                                     : $"{{0:{formatString}}}", 
+                                       parameterValue);
         }
     }
 }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -393,7 +393,7 @@ namespace Refit
                             switch (restMethod.BodyParameterInfo.Item1)
                             {
                             case BodySerializationMethod.UrlEncoded:
-                                ret.Content = new FormUrlEncodedContent(new FormValueDictionary(paramList[i]));
+                                ret.Content = new FormUrlEncodedContent(new FormValueDictionary(paramList[i], settings));
                                 break;
                             case BodySerializationMethod.Json:
                                 var param = paramList[i];


### PR DESCRIPTION
Fixes #411 and #415.

`QueryAttribute` now has a Format property that works for both FormUrlEncoded values and for url encoded values. 
