### PR TITLE
Url Encoding fixes

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -701,11 +701,8 @@ namespace Refit.Tests
             var output = factory(new object[] { 6, "push!=pull&push" });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
-#if NETCOREAPP2_0
+
             Assert.Equal("/foo/bar/6?baz=bamf&search_for=push%21%3Dpull%26push", uri.PathAndQuery);
-#else
-            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push%21%3dpull%26push", uri.PathAndQuery);
-#endif
         }
 
         [Fact]
@@ -713,14 +710,11 @@ namespace Refit.Tests
         {
             var fixture = new RequestBuilderImplementation(typeof(IDummyHttpApi));
             var factory = fixture.BuildRequestFactoryForMethod("FetchSomeStuffWithVoidAndQueryAlias");
-            var output = factory(new object[] { "6", "test@example.com", "push!=pull" });
+            var output = factory(new object[] { "6 & 7/8", "test@example.com", "push!=pull" });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
-#if NETCOREAPP2_0
-            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
-#else
-            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3dpull", uri.PathAndQuery);
-#endif
+
+            Assert.Equal("/void/6%20%26%207%2F8/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
         }
 
         [Fact]
@@ -731,11 +725,8 @@ namespace Refit.Tests
             var output = factory(new object[] { "6/6", "test@example.com", "push!=pull" });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
-#if NETCOREAPP2_0
+
             Assert.Equal("/void/6%2F6/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
-#else
-            Assert.Equal("/void/6%2F6/path?a=test%40example.com&b=push%21%3dpull", uri.PathAndQuery);
-#endif
         }
 
         [Fact]
@@ -746,11 +737,8 @@ namespace Refit.Tests
             var output = factory(new object[] { "6", "test@example.com", "push!=pull" });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
-#if NETCOREAPP2_0
+
             Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
-#else
-            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3dpull", uri.PathAndQuery);
-#endif
         }
 
         [Fact]

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -702,9 +702,9 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 #if NETCOREAPP2_0
-            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push!%3Dpull%26push", uri.PathAndQuery);
+            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push%21%3Dpull%26push", uri.PathAndQuery);
 #else
-            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push!%3dpull%26push", uri.PathAndQuery);
+            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push%21%3dpull%26push", uri.PathAndQuery);
 #endif
         }
 
@@ -717,9 +717,9 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 #if NETCOREAPP2_0
-            Assert.Equal("/void/6/path?a=test@example.com&b=push!%3Dpull", uri.PathAndQuery);
+            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
 #else
-            Assert.Equal("/void/6/path?a=test%40example.com&b=push!%3dpull", uri.PathAndQuery);
+            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3dpull", uri.PathAndQuery);
 #endif
         }
 
@@ -732,9 +732,9 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 #if NETCOREAPP2_0
-            Assert.Equal("/void/6%2F6/path?a=test@example.com&b=push!%3Dpull", uri.PathAndQuery);
+            Assert.Equal("/void/6%2F6/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
 #else
-            Assert.Equal("/void/6%2F6/path?a=test%40example.com&b=push!%3dpull", uri.PathAndQuery);
+            Assert.Equal("/void/6%2F6/path?a=test%40example.com&b=push%21%3dpull", uri.PathAndQuery);
 #endif
         }
 
@@ -747,9 +747,9 @@ namespace Refit.Tests
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 #if NETCOREAPP2_0
-            Assert.Equal("/void/6/path?a=test@example.com&b=push!%3Dpull", uri.PathAndQuery);
+            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3Dpull", uri.PathAndQuery);
 #else
-            Assert.Equal("/void/6/path?a=test%40example.com&b=push!%3dpull", uri.PathAndQuery);
+            Assert.Equal("/void/6/path?a=test%40example.com&b=push%21%3dpull", uri.PathAndQuery);
 #endif
         }
 

--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -698,13 +698,13 @@ namespace Refit.Tests
         {
             var fixture = new RequestBuilderImplementation(typeof(IDummyHttpApi));
             var factory = fixture.BuildRequestFactoryForMethod("FetchSomeStuffWithHardcodedAndOtherQueryParameters");
-            var output = factory(new object[] { 6, "push!=pull" });
+            var output = factory(new object[] { 6, "push!=pull&push" });
 
             var uri = new Uri(new Uri("http://api"), output.RequestUri);
 #if NETCOREAPP2_0
-            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push!%3Dpull", uri.PathAndQuery);
+            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push!%3Dpull%26push", uri.PathAndQuery);
 #else
-            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push!%3dpull", uri.PathAndQuery);
+            Assert.Equal("/foo/bar/6?baz=bamf&search_for=push!%3dpull%26push", uri.PathAndQuery);
 #endif
         }
 

--- a/Refit/HttpUtility.cs
+++ b/Refit/HttpUtility.cs
@@ -3,9 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Text;
-using System.Text.Encodings.Web;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
 
 namespace System.Web
@@ -32,8 +29,6 @@ namespace System.Web
 
             return nvc;
         }
-
-        internal static string UrlEncode(string x) => UrlEncoder.Default.Encode(x);
     }
 }
 #endif

--- a/Refit/Refit.csproj
+++ b/Refit/Refit.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>
   

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -555,7 +555,7 @@ namespace Refit
 
                 if (queryParamsToAdd.Any())
                 {
-                    var pairs = queryParamsToAdd.Select(x => HttpUtility.UrlEncode(x.Key) + "=" + HttpUtility.UrlEncode(x.Value));
+                    var pairs = queryParamsToAdd.Select(x => Uri.EscapeDataString(x.Key) + "=" + Uri.EscapeDataString(x.Value));
                     uri.Query = string.Join("&", pairs);
                 }
                 else

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -384,9 +384,8 @@ namespace Refit
                         urlTarget = Regex.Replace(
                             urlTarget,
                             "{" + restMethod.ParameterMap[i] + "}",
-                            settings.UrlParameterFormatter
-                                    .Format(paramList[i], restMethod.ParameterInfoMap[i])
-                                    .Replace("/", "%2F"),
+                            Uri.EscapeDataString(settings.UrlParameterFormatter
+                                    .Format(paramList[i], restMethod.ParameterInfoMap[i])),
                             RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
                         continue;
                     }


### PR DESCRIPTION
Fixes #298 

Uses `Uri.EscapeDataString` as having the best escaping

https://stackoverflow.com/questions/602642/server-urlencode-vs-httputility-urlencode/47877559#47877559