### PR TITLE
Default to buffered

### DIFF
--- a/Refit.Tests/RequestBuilder.cs
+++ b/Refit.Tests/RequestBuilder.cs
@@ -53,6 +53,9 @@ namespace Refit.Tests
         Task<bool> OhYeahValueTypes(int id, [Body] int whatever);
 
         [Post("/foo/{id}")]
+        Task<bool> OhYeahValueTypesUnbuffered(int id, [Body(buffered: false)] int whatever);
+
+        [Post("/foo/{id}")]
         Task<bool> PullStreamMethod(int id, [Body(buffered: true)] Dictionary<int, string> theData);
 
         [Post("/foo/{id}")]
@@ -288,14 +291,28 @@ namespace Refit.Tests
         }
 
         [Fact]
-        public void ValueTypesDontBlowUp()
+        public void ValueTypesDontBlowUpBuffered()
         {
             var input = typeof(IRestMethodInfoTests);
             var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "OhYeahValueTypes"));
             Assert.Equal("id", fixture.ParameterMap[0]);
             Assert.Empty(fixture.QueryParameterMap);
             Assert.Equal(BodySerializationMethod.Default, fixture.BodyParameterInfo.Item1);
-            Assert.False(fixture.BodyParameterInfo.Item2);
+            Assert.True(fixture.BodyParameterInfo.Item2); // buffered default
+            Assert.Equal(1, fixture.BodyParameterInfo.Item3);
+
+            Assert.Equal(typeof(bool), fixture.SerializedReturnType);
+        }
+
+        [Fact]
+        public void ValueTypesDontBlowUpUnBuffered()
+        {
+            var input = typeof(IRestMethodInfoTests);
+            var fixture = new RestMethodInfo(input, input.GetMethods().First(x => x.Name == "OhYeahValueTypesUnbuffered"));
+            Assert.Equal("id", fixture.ParameterMap[0]);
+            Assert.Empty(fixture.QueryParameterMap);
+            Assert.Equal(BodySerializationMethod.Default, fixture.BodyParameterInfo.Item1);
+            Assert.False(fixture.BodyParameterInfo.Item2); // unbuffered specified
             Assert.Equal(1, fixture.BodyParameterInfo.Item3);
 
             Assert.Equal(typeof(bool), fixture.SerializedReturnType);

--- a/Refit.Tests/RestService.cs
+++ b/Refit.Tests/RestService.cs
@@ -600,7 +600,7 @@ namespace Refit.Tests
 
             mockHttp.Expect(HttpMethod.Post, "http://httpbin.org/foo")
                     .WithContent("\"json string\"")
-                    .WithHeaders("Content-Type", "application/json")
+                    .WithHeaders("Content-Type", "application/json; charset=utf-8")
                     .Respond(HttpStatusCode.OK);
 
             var fixture = RestService.For<IRequestBin>("http://httpbin.org/", settings);

--- a/Refit/Attributes.cs
+++ b/Refit/Attributes.cs
@@ -114,15 +114,30 @@ namespace Refit
     [AttributeUsage(AttributeTargets.Parameter)]
     public class BodyAttribute : Attribute
     {
-        public BodyAttribute(BodySerializationMethod serializationMethod = BodySerializationMethod.Default,
-                             bool buffered = false)
+        public BodyAttribute()
+        {
+
+        }
+        public BodyAttribute(bool buffered)
+        {
+            Buffered = buffered;
+        }
+
+        public BodyAttribute(BodySerializationMethod serializationMethod, bool buffered)
         {
             SerializationMethod = serializationMethod;
             Buffered = buffered;
         }
 
-        public bool Buffered { get; protected set; }
-        public BodySerializationMethod SerializationMethod { get; protected set; }
+        public BodyAttribute(BodySerializationMethod serializationMethod = BodySerializationMethod.Default)
+        {
+            SerializationMethod = serializationMethod;
+        }
+
+
+
+        public bool? Buffered { get; set; }
+        public BodySerializationMethod SerializationMethod { get; protected set; } = BodySerializationMethod.Default;
     }
 
     [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]

--- a/Refit/RefitSettings.cs
+++ b/Refit/RefitSettings.cs
@@ -23,6 +23,7 @@ namespace Refit
         public JsonSerializerSettings JsonSerializerSettings { get; set; }
         public IUrlParameterFormatter UrlParameterFormatter { get; set; }
         public IFormUrlEncodedParameterFormatter FormUrlEncodedParameterFormatter { get; set; }
+        public bool Buffered { get; set; } = true;
     }
 
     public interface IUrlParameterFormatter

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Web;
 using Newtonsoft.Json;
 using System.Collections.Concurrent;
+using System.Net.Http.Headers;
 
 namespace Refit
 {
@@ -456,7 +457,7 @@ namespace Refit
                                                                                         serializer.Serialize(writer, param);
                                                                                     }
                                                                                 },
-                                                                                "application/json");
+                                                                                new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
                                             break;
                                         case true:
                                             ret.Content = new StringContent(

--- a/Refit/RestMethodInfo.cs
+++ b/Refit/RestMethodInfo.cs
@@ -164,7 +164,7 @@ namespace Refit
             return nameAttr?.Name;
         }
 
-        static Tuple<BodySerializationMethod, bool, int> FindBodyParameter(IList<ParameterInfo> parameterList, bool isMultipart, HttpMethod method)
+        Tuple<BodySerializationMethod, bool, int> FindBodyParameter(IList<ParameterInfo> parameterList, bool isMultipart, HttpMethod method)
         {
 
             // The body parameter is found using the following logic / order of precedence:
@@ -192,7 +192,7 @@ namespace Refit
             // #1, body attribute wins
             if (bodyParams.Count == 1) {
                 var ret = bodyParams[0];
-                return Tuple.Create(ret.BodyAttribute.SerializationMethod, ret.BodyAttribute.Buffered, 
+                return Tuple.Create(ret.BodyAttribute.SerializationMethod, ret.BodyAttribute.Buffered ?? RefitSettings.Buffered, 
                     parameterList.IndexOf(ret.Parameter));
             }
 


### PR DESCRIPTION
Fixes #404 by restoring the buffered default. Also adds a global option in the refit settings to be unbuffered.