### PR TITLE
Move PushStreamContent Namespace

### DIFF
--- a/Refit/PushStreamContent.cs
+++ b/Refit/PushStreamContent.cs
@@ -23,11 +23,13 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.IO;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net.Http;
 
-namespace System.Net.Http
+namespace Refit.Net.Http
 {
     /// <summary>
     /// Provides an <see cref="HttpContent"/> implementation that exposes an output <see cref="Stream"/>

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -13,6 +13,7 @@ using System.Web;
 using Newtonsoft.Json;
 using System.Collections.Concurrent;
 using System.Net.Http.Headers;
+using Refit.Net.Http;
 
 namespace Refit
 {


### PR DESCRIPTION
Previous behavior caused issues of mbiguous reference around
PushStreamContent when both Refit and System.Net.Http.Formatting are
included in a project. This is essentially a show stopper to upgrading
to the latest Refit.

The solution is to change the internal implementation of PushStreamContent
namespace from System.Net.Http -> Refit.Net.Http and to update
the usages internally. Note this may be a breaking change to those who
have taken a dependency on PushStreamContent in their own projects from
the Refit assemblies.