### PR TITLE
Exclude private getters from querystring & form posts

### DIFF
--- a/Refit.Tests/FormValueDictionaryTests.cs
+++ b/Refit.Tests/FormValueDictionaryTests.cs
@@ -56,6 +56,31 @@ namespace Refit.Tests
         }
 
         [Fact]
+        public void ExcludesPropertiesWithInaccessibleGetters()
+        {
+            var source = new ClassWithInaccessibleGetters
+            {
+                A = "Foo",
+                B = "Bar"
+            };
+            var expected = new Dictionary<string, string>
+            {
+                { "C", "FooBar" }
+            };
+
+            var actual = new FormValueDictionary(source, settings);
+
+            Assert.Equal(expected, actual);
+        }
+
+        public class ClassWithInaccessibleGetters
+        {
+            public string A { internal get; set; }
+            public string B { private get; set; }
+            public string C => A + B;
+        }
+
+        [Fact]
         public void LoadsFromAnonymousType()
         {
             var source = new

--- a/Refit/FormValueDictionary.cs
+++ b/Refit/FormValueDictionary.cs
@@ -74,7 +74,7 @@ namespace Refit
         PropertyInfo[] GetProperties(Type type)
         {
             return type.GetProperties()
-                       .Where(p => p.CanRead)
+                       .Where(p => p.CanRead && p.GetMethod.IsPublic)
                        .ToArray();
         }
     }

--- a/Refit/RequestBuilderImplementation.cs
+++ b/Refit/RequestBuilderImplementation.cs
@@ -299,8 +299,8 @@ namespace Refit
 
             var kvps = new List<KeyValuePair<string, object>>();
 
-            var bindingFlags = BindingFlags.Instance | BindingFlags.Public;
-            var props = @object.GetType().GetProperties(bindingFlags);
+            var props = @object.GetType().GetProperties()
+                .Where(p => p.CanRead && p.GetMethod.IsPublic);
 
             foreach (var propertyInfo in props)
             {


### PR DESCRIPTION
The way we were reflecting over objects for inclusion in querystrings and form posts was including public properties with inaccessible getters.

Now we make sure that the getter of the property is public.

Fixes #462 